### PR TITLE
IEngineTrace.h

### DIFF
--- a/csgo_internal/csgo_internal/IEngineTrace.h
+++ b/csgo_internal/csgo_internal/IEngineTrace.h
@@ -45,6 +45,26 @@ protected:
 	unsigned long m_Index;
 };
 
+inline CBaseHandle::CBaseHandle()
+{
+	m_Index = INVALID_EHANDLE_INDEX;
+}
+
+inline CBaseHandle::CBaseHandle(const CBaseHandle &other)
+{
+	m_Index = other.m_Index;
+}
+
+inline CBaseHandle::CBaseHandle(unsigned long value)
+{
+	m_Index = value;
+}
+
+inline CBaseHandle::CBaseHandle(int iEntry, int iSerialNumber)
+{
+	Init(iEntry, iSerialNumber);
+}
+
 class ITraceListData
 {
 public:

--- a/csgo_internal/csgo_internal/IEngineTrace.h
+++ b/csgo_internal/csgo_internal/IEngineTrace.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#define INVALID_EHANDLE_INDEX	0xFFFFFFFF
+
 struct virtualmeshlist_t;
 
 class CBaseHandle


### PR DESCRIPTION
Prevents errors when working with CBasehandle when using the cheat as a base

From: [Valve SDK 2013](https://github.com/ValveSoftware/source-sdk-2013/blob/master/mp/src/public/basehandle.h#L73-L91)