### PR TITLE
made it not crash

### DIFF
--- a/csgo_internal/csgo_internal/VTHook.h
+++ b/csgo_internal/csgo_internal/VTHook.h
@@ -85,12 +85,8 @@ private:
 	{
 		DWORD dwIndex = 0;
 
-		for( dwIndex = 0; pdwVMT[ dwIndex ]; dwIndex++ )
-		{
-			if( IsBadCodePtr( ( FARPROC )pdwVMT[ dwIndex ] ) )
-			{
-				break;
-			}
+		while (IsBadCodePtr((FARPROC)pdwVMT[dwIndex]) == false) {
+			dwIndex++;
 		}
 		return dwIndex;
 	}


### PR DESCRIPTION
dwIndex would go past the length of pdwVMT and throw an memory error and this could easily have been done with a while loop so I did just that.