### PR TITLE
Fix Autowall

### DIFF
--- a/csgo_internal/csgo_internal/Autowall.cpp
+++ b/csgo_internal/csgo_internal/Autowall.cpp
@@ -83,7 +83,7 @@ bool CAutowall::HandleBulletPenetration( WeaponInfo_t* wpn_data, FireBulletData&
 {
 	surfacedata_t* enter_surface_data = I::Physprops->GetSurfaceData( data.enter_trace.surface.surfaceProps );
 	int enter_material = enter_surface_data->game.material;
-	float enter_surf_penetration_mod = *( float* )( ( DWORD )enter_surface_data + 76 );
+	float enter_surf_penetration_mod = *( float* )( ( DWORD )enter_surface_data + 88 );
 
 	data.trace_length += data.enter_trace.fraction * data.trace_length_remaining;
 	data.current_damage *= pow( ( wpn_data->flRangeModifier ), ( data.trace_length * 0.002 ) );


### PR DESCRIPTION
I thought someone would've created a pull by now so I just forgot about it.

Off Topic; http://virtuouscheats.com seems like it's now a crappy phishing link. If clicked directly (given a referral) it seems to load to some crappy website which wants me to "prove I'm human" by installing an add-on, and when opened in a new tab it just shows one of those domain for sale sites.